### PR TITLE
Fixed error caused by additional atoms.

### DIFF
--- a/src/groundComp.py
+++ b/src/groundComp.py
@@ -48,6 +48,8 @@ class groundComp:
                 if smt_literals[j][0] == '-':
                     smt_literals[j] = smt_literals[j][1:]
                 atom = smt_literals[j]
+                if atom.isnumeric():
+                  continue
                 if cnf_literals[j] != smt_literals[j] and atom not in self.mapping:
                     self.mapping[atom] = cnf_literals[j].replace("-", "")
         return self.mapping


### PR DESCRIPTION
Something in the pipeline (maybe cmodels maybe gringo) creates additional atoms that do not have a name but only an integer. Example to reproduce:
smoke.lpmln with contents
```
smoke(Y) :- smoke(X), influence(X, Y).
{influence(alice, bob)}.
{influence(bob, carol)}.
{stress(alice)}.
{stress(bob)}.
{stress(carol)}.
-1.6094379124341003 :- stress(alice).
-1.6094379124341003 :- stress(bob).
-1.6094379124341003 :- stress(carol).
-0.2231435513142097 :- not stress(alice).
-0.2231435513142097 :- not stress(bob).
-0.2231435513142097 :- not stress(carol).
smoke(X) :- stress(X).
```
Then `python lpmln_infer.py smoke.lp -sdd -q smoke` leads to an error.
This commit fixes this by ignoring any auxiliary atom that was added.